### PR TITLE
Update lib with .NET Core 3.0 and fix some issues

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -14,10 +14,10 @@
     <RepositoryType>git</RepositoryType>
     <MinClientVersion>3.5</MinClientVersion>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)FubarDev.PamSharp.ruleset</CodeAnalysisRuleSet>
-    <NullableContextOptions>enable</NullableContextOptions>
     <NoWarn>SA1636;SA1641;$(NoWarn)</NoWarn>
+    <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/LoginSharp/LoginSharp.csproj
+++ b/samples/LoginSharp/LoginSharp.csproj
@@ -2,16 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RootNamespace>LoginSharp</RootNamespace>
   </PropertyGroup>
 
   <Import Project="../../Global.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Syslog.Framework.Logging" Version="2.2.0" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
@@ -19,6 +21,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FubarDev.PamSharp\FubarDev.PamSharp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="JetBrains.Annotations" Version="2019.1.3" />
   </ItemGroup>
 
 </Project>

--- a/samples/LoginSharp/Program.cs
+++ b/samples/LoginSharp/Program.cs
@@ -140,7 +140,7 @@ namespace LoginSharp
                     case TargetInvocationException invocationException when invocationException.InnerException != null:
                         exception = invocationException.InnerException;
                         break;
-                    case AggregateException aggregateException:
+                    case AggregateException aggregateException when aggregateException.InnerException != null:
                         exception = aggregateException.InnerException;
                         break;
                 }

--- a/src/FubarDev.PamSharp/DllMap/DllMapItem.cs
+++ b/src/FubarDev.PamSharp/DllMap/DllMapItem.cs
@@ -2,7 +2,9 @@
 // Copyright (c) Fubar Development Junker. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -11,7 +13,7 @@ namespace FubarDev.PamSharp.DllMap
     /// <summary>
     /// Represents a <c>dllmap</c> configuration entry.
     /// </summary>
-    internal class DllMapItem
+    internal class DllMapItem : IEquatable<DllMapItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DllMapItem"/> class.
@@ -59,6 +61,31 @@ namespace FubarDev.PamSharp.DllMap
                     dll.Value,
                     target.Value,
                     DllMapOsSelection.GetOsValues(os?.Value));
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as DllMapItem);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Dll, Target);
+        }
+
+        public bool Equals([AllowNull] DllMapItem other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            var stringComparer = StringComparer.Ordinal;
+            return stringComparer.Equals(Dll, other.Dll) &&
+                   stringComparer.Equals(Target, other.Target) &&
+                   OperatingSystems
+                       .Zip(other.OperatingSystems)
+                       .All(pair => pair.First.Equals(pair.Second));
         }
     }
 }

--- a/src/FubarDev.PamSharp/DllMap/DllMapOsSelection.cs
+++ b/src/FubarDev.PamSharp/DllMap/DllMapOsSelection.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace FubarDev.PamSharp.DllMap
 {
-    internal class DllMapOsSelection
+    internal class DllMapOsSelection : IEquatable<DllMapOsSelection>
     {
         private static readonly ConcurrentDictionary<string, OSPlatform> _wellKnownOsPlatforms =
             new ConcurrentDictionary<string, OSPlatform>(
@@ -70,6 +71,27 @@ namespace FubarDev.PamSharp.DllMap
             return Invert
                 ? !RuntimeInformation.IsOSPlatform(OsPlatform)
                 : RuntimeInformation.IsOSPlatform(OsPlatform);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as DllMapOsSelection);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Invert, OsPlatform);
+        }
+
+        public bool Equals([AllowNull] DllMapOsSelection other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return Invert.Equals(other.Invert) &&
+                   OsPlatform.Equals(other.OsPlatform);
         }
 
         /// <summary>

--- a/src/FubarDev.PamSharp/FubarDev.PamSharp.csproj
+++ b/src/FubarDev.PamSharp/FubarDev.PamSharp.csproj
@@ -27,6 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="dllmap.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Update="JetBrains.Annotations" Version="2019.1.3" />
   </ItemGroup>
 </Project>

--- a/src/FubarDev.PamSharp/FubarDev.PamSharp.csproj
+++ b/src/FubarDev.PamSharp/FubarDev.PamSharp.csproj
@@ -1,18 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Description>PAM bindings for .NET</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn Condition=" '$(Configuration)' != 'Release' ">$(NoWarn);SA1401</NoWarn>
     <AppConfig>app.config</AppConfig>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
+    <RootNamespace>FubarDev.PamSharp</RootNamespace>
   </PropertyGroup>
 
   <Import Project="../../PackageLibrary.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Platform.Invoke" Version="1.2.0" />
-    <PackageReference Include="System.Memory" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,5 +24,9 @@
       <Pack>true</Pack>
       <PackagePath>lib/$(TargetFramework)/$(AssemblyName).dll.config</PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="JetBrains.Annotations" Version="2019.1.3" />
   </ItemGroup>
 </Project>

--- a/src/FubarDev.PamSharp/IPamTransaction.cs
+++ b/src/FubarDev.PamSharp/IPamTransaction.cs
@@ -23,7 +23,7 @@ namespace FubarDev.PamSharp
         /// The use of this event must be enabled with <see cref="EnableFailDelayEvent"/>.
         /// This feature is only available on Linux.
         /// </remarks>
-        event EventHandler<PamDelayEventArgs> Delay;
+        event EventHandler<PamDelayEventArgs>? Delay;
 
         /// <summary>
         /// Gets the PAM transaction handle.
@@ -83,7 +83,7 @@ namespace FubarDev.PamSharp
         /// Gets or sets the X authentication data.
         /// </summary>
         /// <seealso cref="PamItemTypes.PAM_XAUTHDATA"/>
-        PamXAuthData XAuthData { get; set; }
+        PamXAuthData? XAuthData { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the <see cref="Delay"/> event is enabled.

--- a/src/FubarDev.PamSharp/Interop/NaiveDllMap.cs
+++ b/src/FubarDev.PamSharp/Interop/NaiveDllMap.cs
@@ -33,9 +33,10 @@ namespace FubarDev.PamSharp.Interop
             var additionalConfigPath = Path.GetDirectoryName(dllConfigPath) + DllMappingFilename;
 
             IEnumerable<DllMapItem> dllMapItems;
-            if (!File.Exists(dllConfigPath))
+            if (File.Exists(dllConfigPath))
             {
-                dllMapItems = GetDefaultDllMap();
+                var root = XElement.Load(dllConfigPath);
+                dllMapItems = DllMapItem.LoadDllMap(root.Elements("dllmap"));
             }
             else if (File.Exists(additionalConfigPath))
             {
@@ -44,8 +45,7 @@ namespace FubarDev.PamSharp.Interop
             }
             else
             {
-                var root = XElement.Load(dllConfigPath);
-                dllMapItems = DllMapItem.LoadDllMap(root.Elements("dllmap"));
+                dllMapItems = GetDefaultDllMap();
             }
 
             var items = Filter(dllMapItems, libraryName);

--- a/src/FubarDev.PamSharp/Interop/PamInteropFactory.cs
+++ b/src/FubarDev.PamSharp/Interop/PamInteropFactory.cs
@@ -27,15 +27,20 @@ namespace FubarDev.PamSharp.Interop
         /// <returns>a new object that implements the PAM API.</returns>
         public static IPamInterop Create()
         {
-            lock (_lock)
+            if (_interop == null)
             {
-                if (_interop == null)
+                lock (_lock)
                 {
-                    _interop = CreatePamInterop();
-                }
+                    if (_interop == null)
+                    {
+                        _interop = CreatePamInterop();
+                    }
 
-                return _interop;
+                    return _interop;
+                }
             }
+
+            return _interop;
         }
 
         /// <summary>
@@ -82,7 +87,7 @@ namespace FubarDev.PamSharp.Interop
             }
 
             throw new AggregateException(
-                "Unsupported operating system, no viable library loader or library not found",
+                "Unsupported operating system, no viable library loader or library not found.",
                 exceptions);
         }
 

--- a/src/FubarDev.PamSharp/Interop/PamInteropFactory.cs
+++ b/src/FubarDev.PamSharp/Interop/PamInteropFactory.cs
@@ -88,7 +88,8 @@ namespace FubarDev.PamSharp.Interop
 
             throw new AggregateException(
                 "Unsupported operating system, no viable library loader or library not found.",
-                exceptions);
+                exceptions
+            );
         }
 
         private static IEnumerable<ILibraryLoader> GetLibraryLoaders()

--- a/src/FubarDev.PamSharp/MarshalUtils.cs
+++ b/src/FubarDev.PamSharp/MarshalUtils.cs
@@ -21,7 +21,9 @@ namespace FubarDev.PamSharp
         public static string? PtrToStringUTF8(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
+            {
                 return null;
+            }
 
             return Marshal.PtrToStringUTF8(ptr);
         }

--- a/src/FubarDev.PamSharp/MessageHandlers/ConsoleMessageHandler.cs
+++ b/src/FubarDev.PamSharp/MessageHandlers/ConsoleMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConsoleMessageHandler.cs" company="Fubar Development Junker">
+// <copyright file="ConsoleMessageHandler.cs" company="Fubar Development Junker">
 // Copyright (c) Fubar Development Junker. All rights reserved.
 // </copyright>
 
@@ -88,7 +88,7 @@ namespace FubarDev.PamSharp.MessageHandlers
 
             try
             {
-                var input = Console.In.ReadLine();
+                var input = Console.In.ReadLine() ?? string.Empty;
                 return PamResponse<string>.Success(input);
             }
             catch (Exception ex)

--- a/src/FubarDev.PamSharp/PamConversationHandler.cs
+++ b/src/FubarDev.PamSharp/PamConversationHandler.cs
@@ -25,7 +25,7 @@ namespace FubarDev.PamSharp
         /// <param name="messageHandler">The message handler that gets the messages.</param>
         public PamConversationHandler(IPamMessageHandler messageHandler)
         {
-            _messageHandler = messageHandler ?? throw new ArgumentNullException();
+            _messageHandler = messageHandler ?? throw new ArgumentNullException(nameof(messageHandler));
         }
 
         private interface IPamResponse

--- a/src/FubarDev.PamSharp/PamConversationHandler.cs
+++ b/src/FubarDev.PamSharp/PamConversationHandler.cs
@@ -100,7 +100,7 @@ namespace FubarDev.PamSharp
                         yield return new PamBinaryResponse(messageHandler.BinaryPrompt(msg.Payload));
                         break;
                     default:
-                        throw new NotSupportedException($"Message style {message.MessageStyle} not supported");
+                        throw new NotSupportedException($"Message style {message.MessageStyle.ToString()} not supported.");
                 }
             }
         }
@@ -141,7 +141,7 @@ namespace FubarDev.PamSharp
                         result.Add(ReadBinaryInfo(message));
                         break;
                     default:
-                        throw new NotSupportedException($"Message style {messageStyle} not supported");
+                        throw new NotSupportedException($"Message style {messageStyle.ToString()} not supported.");
                 }
             }
 
@@ -161,7 +161,7 @@ namespace FubarDev.PamSharp
 
         private static unsafe IPamMessage ReadTextInfo(PamMessage* messagePtr, Func<string, IPamMessage> createMessageFunc)
         {
-            var text = Marshal.PtrToStringUTF8(messagePtr->Message);
+            var text = Marshal.PtrToStringUTF8(messagePtr->Message) ?? string.Empty;
             return createMessageFunc(text);
         }
 

--- a/src/FubarDev.PamSharp/PamException.cs
+++ b/src/FubarDev.PamSharp/PamException.cs
@@ -38,12 +38,12 @@ namespace FubarDev.PamSharp
         /// <param name="handle">The PAM handle.</param>
         /// <param name="status">The error status.</param>
         /// <returns>The error message.</returns>
-        private static string GetPamError(IPamInterop interop, IntPtr handle, int status)
+        private static string? GetPamError(IPamInterop interop, IntPtr handle, int status)
         {
             var result = interop.pam_strerror(handle, status);
             if (result == IntPtr.Zero)
             {
-                return $"Error ({status})";
+                return $"Error ({status.ToString()}).";
             }
 
             return Marshal.PtrToStringUTF8(result);

--- a/src/FubarDev.PamSharp/PamFlags.cs
+++ b/src/FubarDev.PamSharp/PamFlags.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PamFlags.cs" company="Fubar Development Junker">
+// <copyright file="PamFlags.cs" company="Fubar Development Junker">
 // Copyright (c) Fubar Development Junker. All rights reserved.
 // </copyright>
 
@@ -13,37 +13,37 @@ namespace FubarDev.PamSharp
     public enum PamFlags
     {
         /// <summary>
-        /// Authentication service should not generate any messages
+        /// Authentication service should not generate any messages.
         /// </summary>
         PAM_SILENT = 0x8000,
 
         /// <summary>
-        /// The authentication service should return <see cref="PamStatus.PAM_AUTH_ERR"/> if the user has a null authentication token
+        /// The authentication service should return <see cref="PamStatus.PAM_AUTH_ERR"/> if the user has a null authentication token.
         /// </summary>
         PAM_DISALLOW_NULL_AUTHTOK = 0x0001,
 
         /// <summary>
-        /// Initialize the credentials for the user
+        /// Initialize the credentials for the user.
         /// </summary>
         PAM_ESTABLISH_CRED = 0x0002,
 
         /// <summary>
-        /// Delete the user's credentials
+        /// Delete the user's credentials.
         /// </summary>
         PAM_DELETE_CRED = 0x0004,
 
         /// <summary>
-        /// Fully reinitialize the user's credentials
+        /// Fully reinitialize the user's credentials.
         /// </summary>
         PAM_REINITIALIZE_CRED = 0x0008,
 
         /// <summary>
-        /// Extend the lifetime of the existing credentials
+        /// Extend the lifetime of the existing credentials.
         /// </summary>
         PAM_REFRESH_CRED = 0x0010,
 
         /// <summary>
-        /// The users authentication token (password) should only be changed if it has expired
+        /// The users authentication token (password) should only be changed if it has expired.
         /// </summary>
         PAM_CHANGE_EXPIRED_AUTHTOK = 0x0020,
     }

--- a/src/FubarDev.PamSharp/PamResponse{T}.cs
+++ b/src/FubarDev.PamSharp/PamResponse{T}.cs
@@ -53,7 +53,10 @@ namespace FubarDev.PamSharp
         public static PamResponse<T> Error(PamStatus status)
         {
             if (status == PamStatus.PAM_SUCCESS)
-                throw new ArgumentOutOfRangeException(nameof(status), "Status must not indicate success");
+            {
+                throw new ArgumentOutOfRangeException(nameof(status), status, "Status must not indicate success.");
+            }
+
             return new PamResponse<T>(status, () => throw new InvalidOperationException("No payload available."));
         }
     }

--- a/src/FubarDev.PamSharp/PamService.cs
+++ b/src/FubarDev.PamSharp/PamService.cs
@@ -73,7 +73,7 @@ namespace FubarDev.PamSharp
             if (result != PamStatus.PAM_SUCCESS)
             {
                 _logger.LogError("Action {0} failed with status {1}", caller, result);
-                throw new PamException(_interop, IntPtr.Zero, result);
+                throw new PamException(_interop, IntPtr.Zero, result, caller);
             }
         }
     }

--- a/src/FubarDev.PamSharp/PamService.cs
+++ b/src/FubarDev.PamSharp/PamService.cs
@@ -72,7 +72,7 @@ namespace FubarDev.PamSharp
         {
             if (result != PamStatus.PAM_SUCCESS)
             {
-                _logger.LogError("Action {0} failed with status {1}", caller, result);
+                _logger?.LogError("Action {0} failed with status {1}", caller, result);
                 throw new PamException(_interop, IntPtr.Zero, result, caller);
             }
         }

--- a/src/FubarDev.PamSharp/PamStatusHelper.cs
+++ b/src/FubarDev.PamSharp/PamStatusHelper.cs
@@ -1,0 +1,83 @@
+namespace FubarDev.PamSharp
+{
+    internal static class PamStatusHelper
+    {
+        /// <summary>
+        /// Transforms status to its description from PAM header (_pam_types.h).
+        /// </summary>
+        /// <param name="status">Status to convert.</param>
+        /// <param name="invokedMethod">Name of invoked PAM action.</param>
+        /// <returns>Formatted message with info about status.</returns>
+        public static string TransformStatusToString(PamStatus status, string invokedMethod)
+        {
+            return status switch
+            {
+                PamStatus.PAM_SUCCESS => $"{status.ToString()}. Successful function return.",
+
+                PamStatus.PAM_OPEN_ERR => $"{status.ToString()}. dlopen() failure when dynamically loading a service module.",
+
+                PamStatus.PAM_SYMBOL_ERR => $"{status.ToString()}. Symbol not found.",
+
+                PamStatus.PAM_SERVICE_ERR => $"{status.ToString()}. Error in service module.",
+
+                PamStatus.PAM_SYSTEM_ERR => $"{status.ToString()}. System error.",
+
+                PamStatus.PAM_BUF_ERR => $"{status.ToString()}. Memory buffer error.",
+
+                PamStatus.PAM_PERM_DENIED => $"{status.ToString()}. Permission denied.",
+
+                PamStatus.PAM_AUTH_ERR => $"{status.ToString()}. Authentication failure.",
+
+                PamStatus.PAM_CRED_INSUFFICIENT => $"{status.ToString()}. Can not access authentication data due to insufficient credentials.",
+
+                PamStatus.PAM_AUTHINFO_UNAVAIL => $"{status.ToString()}. Underlying authentication service can not retrieve authentication information.",
+
+                PamStatus.PAM_USER_UNKNOWN => $"{status.ToString()}. User not known to the underlying authenticaiton module.",
+
+                PamStatus.PAM_MAXTRIES => $"{status.ToString()}. An authentication service has maintained a retry count which has been reached.  No further retries should be attempted.",
+
+                PamStatus.PAM_NEW_AUTHTOK_REQD => $"{status.ToString()}. New authentication token required. This is normally returned if the machine security policies require that the password should be changed beccause the password is NULL or it has aged.",
+
+                PamStatus.PAM_ACCT_EXPIRED => $"{status.ToString()}. User account has expired.",
+
+                PamStatus.PAM_SESSION_ERR => $"{status.ToString()}. Can not make/remove an entry for the specified session.",
+
+                PamStatus.PAM_CRED_UNAVAIL => $"{status.ToString()}. Underlying authentication service can not retrieve user credentials unavailable.",
+
+                PamStatus.PAM_CRED_EXPIRED => $"{status.ToString()}. User credentials expired",
+
+                PamStatus.PAM_CRED_ERR => $"{status.ToString()}. Failure setting user credentials.",
+
+                PamStatus.PAM_NO_MODULE_DATA => $"{status.ToString()}. No module specific data is present.",
+
+                PamStatus.PAM_CONV_ERR => $"{status.ToString()}. Conversation error.",
+
+                PamStatus.PAM_AUTHTOK_ERR => $"{status.ToString()}. Authentication token manipulation error.",
+
+                PamStatus.PAM_AUTHTOK_RECOVERY_ERR => $"{status.ToString()}. Authentication information cannot be recovered.",
+
+                PamStatus.PAM_AUTHTOK_LOCK_BUSY => $"{status.ToString()}. Authentication token lock busy.",
+
+                PamStatus.PAM_AUTHTOK_DISABLE_AGING => $"{status.ToString()}. Authentication token aging disabled.",
+
+                PamStatus.PAM_TRY_AGAIN => $"{status.ToString()}. Preliminary check by password service.",
+
+                PamStatus.PAM_IGNORE => $"{status.ToString()}. Ignore underlying account module regardless of whether the control flag is required, optional, or sufficient.",
+
+                PamStatus.PAM_ABORT => $"{status.ToString()}. Critical error (?module fail now request).",
+
+                PamStatus.PAM_AUTHTOK_EXPIRED => $"{status.ToString()}. User's authentication token has expired.",
+
+                PamStatus.PAM_MODULE_UNKNOWN => $"{status.ToString()}. Module is not known.",
+
+                PamStatus.PAM_BAD_ITEM => $"{status.ToString()}. Bad item passed to pam_*_item().",
+
+                PamStatus.PAM_CONV_AGAIN => $"{status.ToString()}. Conversation function is event driven and data is not available yet.",
+
+                PamStatus.PAM_INCOMPLETE => $"{status.ToString()}. Please call {invokedMethod} function again to complete authentication stack. Before calling again, verify that conversation is completed.",
+
+                _ => $"{status.ToString()}. Unknown PAM status code.",
+            };
+        }
+    }
+}

--- a/src/FubarDev.PamSharp/PamStatusHelper.cs
+++ b/src/FubarDev.PamSharp/PamStatusHelper.cs
@@ -1,3 +1,7 @@
+// <copyright file="PamStatusHelper.cs" company="Fubar Development Junker">
+// Copyright (c) Fubar Development Junker. All rights reserved.
+// </copyright>
+
 namespace FubarDev.PamSharp
 {
     internal static class PamStatusHelper

--- a/src/FubarDev.PamSharp/PamTransaction.cs
+++ b/src/FubarDev.PamSharp/PamTransaction.cs
@@ -350,7 +350,7 @@ namespace FubarDev.PamSharp
                 _logger?.LogError("Action {0} failed with status {1}", caller, result);
                 _lastStatus = result;
                 var handle = _disposed ? IntPtr.Zero : Handle;
-                throw new PamException(_interop, handle, result);
+                throw new PamException(_interop, handle, result, caller);
             }
         }
 

--- a/src/FubarDev.PamSharp/dllmap.config
+++ b/src/FubarDev.PamSharp/dllmap.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <!-- Some default DLL mappings -->
+  <dllmap dll="pam" os="Linux" target="libpam.so.0" />
+  <dllmap dll="pam" os="Linux" target="libpam.so" />
+  <dllmap dll="pam" os="FreeBSD" target="libpam.so.0" />
+  <dllmap dll="pam" os="FreeBSD" target="libpam.so" />
+  <dllmap dll="pam" os="OSX" target="libpam.2.dylib" />
+  <dllmap dll="pam" os="OSX" target="libpam.1.dylib" />
+  <dllmap dll="pam" os="OSX" target="libpam.dylib" />
+</configuration>

--- a/test/FubarDev.PamSharp.Tests/DllMapTests.cs
+++ b/test/FubarDev.PamSharp.Tests/DllMapTests.cs
@@ -2,11 +2,12 @@
 // Copyright (c) Fubar Development Junker. All rights reserved.
 // </copyright>
 
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
 
 using FubarDev.PamSharp.DllMap;
-
+using FubarDev.PamSharp.Interop;
 using Xunit;
 
 namespace FubarDev.PamSharp.Tests
@@ -142,6 +143,18 @@ namespace FubarDev.PamSharp.Tests
                     Assert.False(osSelection.Invert);
                     Assert.Equal("WHATEVER", osSelection.OsPlatform.ToString());
                 });
+        }
+
+        [Fact]
+        public void CompareDefaultDllMappingWithConifgFile()
+        {
+            var defaultDllMapItems = NaiveDllMap.GetDefaultDllMap().ToList();
+
+            var additionalConfigPath = NaiveDllMap.ConstructAdditionalConfigFile(typeof(IPamService).Assembly.Location);
+            var root = XElement.Load(additionalConfigPath);
+            var configDllMapItems = DllMapItem.LoadDllMap(root.Elements("dllmap")).ToList();
+
+            Assert.Equal(defaultDllMapItems, configDllMapItems);
         }
     }
 }

--- a/test/FubarDev.PamSharp.Tests/FubarDev.PamSharp.Tests.csproj
+++ b/test/FubarDev.PamSharp.Tests/FubarDev.PamSharp.Tests.csproj
@@ -1,17 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <UserSecretsId>14089114-ace5-4c46-bf3e-a4df131165d9</UserSecretsId>
     <NoWarn>SA1401;$(NoWarn)</NoWarn>
+    <RootNamespace>FubarDev.PamSharp.Tests</RootNamespace>
   </PropertyGroup>
   <Import Project="../../Global.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -19,5 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FubarDev.PamSharp\FubarDev.PamSharp.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="JetBrains.Annotations" Version="2019.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi! I liked this PAM wrapper. It handles a lot of cases and looks pretty good. But I've found some issues when I started to use this lib. The changes are:

- Updated projects to .NET Core 3.0 and enabled nullable reference from the release version of C# 8.0;
- Fixed almost all nullable warnings (except implementations of `ICustomMarshaler`);
- Fixed issue with `ArgumentNullException` if logger has not been initialized for `PamTransaction`;
- Added additional check for `PamInteropFactory` if `_interop` has already been created (to avoid `lock` call);
- Added status converter to create exceptions with descriptive messages if the PAM method returns nothing.

I think that if you start to use nullable reference (it's C# 8.0 feature) it would be better to use .NET Core 3.0 instead of .NET Core 2.2 (which is used currently).

What do you think about it?